### PR TITLE
feat: add Cmd+Shift+H/L shortcuts for tab navigation

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -8,7 +8,7 @@ import { invoke } from '@tauri-apps/api/core';
  * Automatically syncs with active note, handles focus, and saves on change.
  */
 export function Editor() {
-  const { activeNote, upsertNoteContent, setCopyStatus, createNewNote, activeId, deleteNote } = useStore();
+  const { activeNote, upsertNoteContent, setCopyStatus, createNewNote, activeId, deleteNote, activateNextNote, activatePrevNote } = useStore();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const note = activeNote();
@@ -71,6 +71,8 @@ export function Editor() {
         onNewMemo: handleNewMemo,
         onDeleteTab: handleDeleteTab,
         onQuit: handleQuit,
+        onNextTab: activateNextNote,
+        onPrevTab: activatePrevNote,
       });
 
       return () => {
@@ -83,7 +85,7 @@ export function Editor() {
     return () => {
       cleanupPromise.then((cleanup) => cleanup?.());
     };
-  }, [content, setCopyStatus, createNewNote, activeId, deleteNote, handleQuit]);
+  }, [content, setCopyStatus, createNewNote, activeId, deleteNote, handleQuit, activateNextNote, activatePrevNote]);
 
   /**
    * Handle text change - save to store immediately

--- a/src/lib/commands/app-commands.ts
+++ b/src/lib/commands/app-commands.ts
@@ -10,6 +10,8 @@ export interface CommandHandlers {
   onNewMemo: () => void;
   onDeleteTab: () => void;
   onQuit: () => void;
+  onNextTab: () => void;
+  onPrevTab: () => void;
 }
 
 /**
@@ -68,6 +70,20 @@ export async function setupKeyboardShortcuts(
     if ((e.metaKey || e.ctrlKey) && e.key === 'w') {
       e.preventDefault();
       handlers.onDeleteTab();
+      return;
+    }
+
+    // Cmd+Shift+L - Next Tab
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
+      e.preventDefault();
+      handlers.onNextTab();
+      return;
+    }
+
+    // Cmd+Shift+H - Previous Tab
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'h') {
+      e.preventDefault();
+      handlers.onPrevTab();
       return;
     }
 

--- a/src/services/repo.ts
+++ b/src/services/repo.ts
@@ -47,6 +47,8 @@ const DEFAULT_SHORTCUTS = {
   copy: { ctrlKey: true, shiftKey: false, altKey: false, key: 'c' },
   newMemo: { ctrlKey: true, shiftKey: false, altKey: false, key: 'n' },
   deleteMemo: { ctrlKey: true, shiftKey: false, altKey: false, key: 'w' },
+  nextTab: { ctrlKey: true, shiftKey: true, altKey: false, key: 'l' },
+  prevTab: { ctrlKey: true, shiftKey: true, altKey: false, key: 'h' },
 };
 
 /**
@@ -89,6 +91,8 @@ function validateSettings(settings: unknown): Settings {
       copy: validateShortcutKey(sc.copy),
       newMemo: validateShortcutKey(sc.newMemo),
       deleteMemo: validateShortcutKey(sc.deleteMemo),
+      nextTab: validateShortcutKey(sc.nextTab),
+      prevTab: validateShortcutKey(sc.prevTab),
     };
   }
 

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -28,6 +28,8 @@ interface Store extends AppStateShape {
   setOpacity: (opacity: number) => void;
   setShortcuts: (shortcuts: ShortcutSettings) => void;
   setCopyStatus: (status: 'idle' | 'copied') => void;
+  activateNextNote: () => void;
+  activatePrevNote: () => void;
 }
 
 /**
@@ -81,6 +83,8 @@ export const useStore = create<Store>((set, get) => ({
       copy: { ctrlKey: true, shiftKey: false, altKey: false, key: 'c' },
       newMemo: { ctrlKey: true, shiftKey: false, altKey: false, key: 'n' },
       deleteMemo: { ctrlKey: true, shiftKey: false, altKey: false, key: 'w' },
+      nextTab: { ctrlKey: true, shiftKey: true, altKey: false, key: 'l' },
+      prevTab: { ctrlKey: true, shiftKey: true, altKey: false, key: 'h' },
     },
   },
   copyStatus: 'idle',
@@ -273,6 +277,24 @@ export const useStore = create<Store>((set, get) => ({
 
       return newState;
     });
+  },
+
+  // Action: Activate next note (wrap around)
+  activateNextNote: () => {
+    const { notes, activeId } = get();
+    if (notes.length <= 1) return;
+    const currentIndex = notes.findIndex((n) => n.id === activeId);
+    const nextIndex = (currentIndex + 1) % notes.length;
+    set({ activeId: notes[nextIndex].id });
+  },
+
+  // Action: Activate previous note (wrap around)
+  activatePrevNote: () => {
+    const { notes, activeId } = get();
+    if (notes.length <= 1) return;
+    const currentIndex = notes.findIndex((n) => n.id === activeId);
+    const prevIndex = (currentIndex - 1 + notes.length) % notes.length;
+    set({ activeId: notes[prevIndex].id });
   },
 
   // Action: Set copy status (transient state)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,14 @@ export type ShortcutSettings = {
    * Delete current memo shortcut (default: Cmd+W)
    */
   deleteMemo: ShortcutKey;
+  /**
+   * Switch to next tab (default: Cmd+Shift+L)
+   */
+  nextTab: ShortcutKey;
+  /**
+   * Switch to previous tab (default: Cmd+Shift+H)
+   */
+  prevTab: ShortcutKey;
 };
 
 /**


### PR DESCRIPTION
## Summary
- `⌘+Shift+L` で次のタブ、`⌘+Shift+H` で前のタブに移動するキーボードショートカットを追加
- 最後/最初のタブでラップアラウンド対応
- タブが1つのみの場合は何もしない

Closes #11

## Test plan
- [ ] 複数タブ状態で `⌘+Shift+L` → 次のタブに移動
- [ ] `⌘+Shift+H` → 前のタブに移動
- [ ] 最後のタブで `⌘+Shift+L` → 最初のタブにラップ
- [ ] 最初のタブで `⌘+Shift+H` → 最後のタブにラップ
- [ ] タブが1つのみ → 何も起きない
- [ ] 既存ショートカット（⌘+C, ⌘+N, ⌘+W, Esc, ⌘+Q）が引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)